### PR TITLE
Add ROS2 Foxy to Webots dockerfile and other minor fixes

### DIFF
--- a/Dockerfile.Webots
+++ b/Dockerfile.Webots
@@ -5,6 +5,17 @@ LABEL maintainer="Emiliano Borghi"
 ENV USER=create2
 ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES},display
 
+# install packages
+RUN apt-get update && apt-get -q -y install --no-install-recommends \
+    bash-completion \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    python3-pip \
+    sudo \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create a user with passwordless sudo
 ARG UID
 USER root
@@ -17,7 +28,65 @@ ENV PYTHONPATH=${PYTHONPATH}:${WEBOTS_HOME}/lib/controller/python3
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${WEBOTS_HOME}/lib/controller
 
 # Audio support
-RUN usermod -aG audio ${USER}
+RUN usermod -aG audio $USER
 RUN apt-get update && apt-get install -y alsa-utils
 
+# ROS 2 Foxy
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+RUN apt-get update && apt-get install -y \
+    ros-foxy-ros-base \
+    ros-foxy-webots-ros2
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# install python packages
+RUN pip3 install -U \
+    argcomplete \
+    flake8 \
+    flake8-blind-except \
+    flake8-builtins \
+    flake8-class-newline \
+    flake8-comprehensions \
+    flake8-deprecated \
+    flake8-docstrings \
+    flake8-import-order \
+    flake8-quotes \
+    pytest-repeat \
+    pytest-rerunfailures
+# This is a workaround for pytest not found causing builds to fail
+# Following RUN statements tests for regression of https://github.com/ros2/ros2/issues/722
+RUN pip3 freeze | grep pytest \
+    && python3 -m pytest --version
+
+# Permissions to workspace
+RUN mkdir -p /home/$USER/colcon_ws
+RUN chown -R $USER:$USER /home/$USER/colcon_ws
+
+# Webots config
+RUN mkdir -p /home/$USER/.config/Cyberbotics
+COPY --chown=$USER:$USER Webots-R2021a.conf /home/$USER/.config/Cyberbotics/Webots-R2021a.conf
+
 USER $USER
+
+# setup ros2 environment
+RUN echo ". /opt/ros/foxy/setup.bash" >> /home/$USER/.bashrc
+ENV COLCON_SETUP_BASH "/home/$USER/colcon_ws/devel/setup.bash"
+RUN echo "[[ -f ${COLCON_SETUP_BASH} ]] && . ${COLCON_SETUP_BASH}" >> /home/$USER/.bashrc

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ make create2_webots
 ### Run
 
 ```bash
-./run_webots.sh [webots]
+./run_webots.sh [bash]
 ```
 
-You can replace `[webots]` with any other command.
+You can replace `[bash]` with any other command.

--- a/Webots-R2021a.conf
+++ b/Webots-R2021a.conf
@@ -1,0 +1,15 @@
+[%General]
+checkWebotsUpdateOnStartup=false
+disableSaveWarning=false
+startupMode=Pause
+telemetry=false
+theme=webots_night.qss
+
+[Internal]
+firstLaunch=false
+
+[OpenGL]
+GTAO=4
+disableAntiAliasing=false
+disableShadows=false
+textureQuality=2

--- a/run_webots.sh
+++ b/run_webots.sh
@@ -6,17 +6,13 @@ xhost +local:root
 docker run -it --rm \
   --env="DISPLAY" \
   --env="QT_X11_NO_MITSHM=1" \
+  --workdir="/home/create2/colcon_ws" \
+  --volume="/home/$USER/colcon_ws:/home/create2/colcon_ws/src" \
   --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-  --workdir="/home/$USER" \
-  --volume="/home/$USER:/home/$USER" \
-  --volume="/etc/group:/etc/group:ro" \
-  --volume="/etc/passwd:/etc/passwd:ro" \
-  --volume="/etc/shadow:/etc/shadow:ro" \
-  --volume="/etc/sudoers.d:/etc/sudoers.d:ro" \
-  --device "/dev/snd" \
-  --group-add audio \
-  --gpus=all \
-  --network=host \
+  --device="/dev/snd" \
+  --group-add="audio" \
+  --gpus="all" \
+  --network="host" \
   create2/webots $@
 
 xhost -local:root


### PR DESCRIPTION
This PR installs ROS 2 Foxy in Webots dockerfile besides:

- Persisting Webots configurations
- Mounting only `colcon_ws` directory