### PR TITLE
Add several services to docker-compose

### DIFF
--- a/Dockerfile.Webots
+++ b/Dockerfile.Webots
@@ -83,7 +83,12 @@ RUN chown -R $USER:$USER /colcon_ws
 RUN mkdir -p /home/$USER/.config/Cyberbotics
 COPY --chown=$USER:$USER Webots-R2021a.conf /home/$USER/.config/Cyberbotics/Webots-R2021a.conf
 
+# rosdep
+RUN apt-get update
+RUN rosdep init
+
 USER $USER
+RUN rosdep update
 
 # setup ros2 environment
 RUN echo ". /opt/ros/foxy/setup.bash" >> /home/$USER/.bashrc

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Docker images to control a real iRobot Create 2 with ROS 2 and simulate it in We
 
 - `nvidia-container-toolkit`
 
+- Create your workspace locally in `/home/$USER/colcon_ws`
+
 ### Installation
 
 Please refer to [official site](https://docs.docker.com/compose/install/).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,13 +5,13 @@
 version: "3.4"
 
 services:
+  # Simulation
   webots_simulation:
     build:
       context: .
       dockerfile: Dockerfile.Webots
-    command: bash -c "cd /colcon_ws && colcon build && . /colcon_ws/install/setup.bash && ros2 launch create2_description spawn_robot.launch.py"
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
+      network: host
+    command: bash -c ". /entrypoint.sh create2_description spawn_robot.launch.py"
     container_name: webots_simulation
     deploy:
       resources:
@@ -27,27 +27,63 @@ services:
       - QT_X11_NO_MITSHM=1
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
-    network_mode: "host"
+    #network_mode: "host"
     privileged: true
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
     user: create2
     volumes:
-      - /home/$USER/colcon_ws:/colcon_ws:rw
+      - /home/$USER/colcon_ws/src/create2_description:/colcon_ws/src/create2_description:rw
+      # TODO: We have our own copy of webots_ros2 with changes
+      - /home/$USER/colcon_ws/src/webots_ros2:/colcon_ws/src/webots_ros2:rw
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ./entrypoint.sh:/entrypoint.sh
     working_dir: /colcon_ws
 
+  # Robot hardware
   hardware:
     image: osrf/ros:foxy-desktop
-    command: bash
+    command: bash -c ". /entrypoint.sh create2_hardware standalone.launch.py"
     container_name: hardware
     devices:
-      - /dev/dri
-      - /dev/snd
-    environment:
-      - DISPLAY=${DISPLAY}
-    network_mode: "host"
+      - /dev/usb
+    network_mode: host
     privileged: true
-    user: root
-    tty: yes # Without a tty, rclpy/rclcpp infinitely buffer standard out
+    stdin_open: true
+    tty: true
     volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /home/$USER/colcon_ws/src/create2_hardware:/colcon_ws/src/create2_hardware:rw
+      - ./entrypoint.sh:/entrypoint.sh
+    working_dir: /colcon_ws
+
+  # Software stack
+  services:
+    image: osrf/ros:foxy-desktop
+    command: bash -c ". /entrypoint.sh create2_vision pointcloud.launch.py"
+    container_name: services
+    network_mode: host
+    privileged: true
+    stdin_open: true
+    tty: true
+    volumes:
+      - /home/$USER/colcon_ws/src/create2_vision:/colcon_ws/src/create2_vision:rw
+      - ./entrypoint.sh:/entrypoint.sh
+    working_dir: /colcon_ws
+
+  # Development
+  # docker-compose run --rm dev
+  dev:
+    image: osrf/ros:foxy-desktop
+    command: /bin/bash
+    container_name: dev
+    depends_on:
+      - webots_simulation
+    network_mode: host
+    privileged: true
+    stdin_open: true
+    tty: true
+    volumes:
+      - /home/$USER/colcon_ws:/colcon_ws:rw
+      - ./entrypoint.sh:/entrypoint.sh
+    working_dir: /colcon_ws
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# 
+# Script to update-build-run workspace for docker-compose services
+# 
+# Author: Emiliano J. Borghi Orue
+
+# Check arguments
+if [ "$#" -ne 2 ]; then
+    echo "Illegal number of parameters. Two are expected: ROS package and launchfile."
+    echo "Eg: turtlesim turtlesim multisim.launch.py"
+    exit -1
+fi
+
+# Arguments
+PACKAGE_NAME=$1
+LAUNCHFILE_NAME=$2
+
+# Source ROS 2
+. /opt/ros/foxy/setup.bash && \
+# Retrieve new lists of packages
+sudo apt-get update && \
+# Install workspace dependencies
+rosdep install --from-path /colcon_ws/src -yi --rosdistro=foxy && \
+# Build workspace
+colcon build --symlink-install && \
+# Source workspace
+. /colcon_ws/install/setup.bash && \
+# Execute launchfile
+ros2 launch $PACKAGE_NAME $LAUNCHFILE_NAME


### PR DESCRIPTION
This PR adds a few changes:

- Add entrypoint script to make some changes at runtime (when the docker-compose image is executed)
- Added `services`, `hardware` and `dev` services